### PR TITLE
Add button to set keyword in stats tab

### DIFF
--- a/template/sheet/tab/stats.html
+++ b/template/sheet/tab/stats.html
@@ -51,6 +51,9 @@
       </div>
       {{/if}}
       {{/each}}
+      <div class="button">
+        <a class="item-create" title="Add Keyword" data-type="keyword"><i class="fas fa-plus"></i></a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This is suppose to fix #12 .

So I found out that I could just add an "Add Keyword" button in the menu. This looks like that:
![Screenshot from 2021-05-20 20-49-46](https://user-images.githubusercontent.com/63260853/119032973-020fc200-b9ad-11eb-846f-0e97c058097d.png)
