### PR TITLE
Automate XP costs for skills and attributes

### DIFF
--- a/scripts/common/actor.js
+++ b/scripts/common/actor.js
@@ -57,7 +57,7 @@ export class WrathAndGloryActor extends Actor {
     _computeItems() {
         this.combat.resilence.armor = 0;
         for (let item of this.items) {
-    
+
             if (item.isArmour) {
                 this._computeArmour(item);
             }
@@ -79,6 +79,7 @@ export class WrathAndGloryActor extends Actor {
     _computeAttributes() {
         for (let attribute of Object.values(this.attributes)) {
             attribute.total = attribute.rating + attribute.bonus;
+            attribute.cost = this.getAttributeCosts(attribute.rating);
             if (this.advances) {
                 this.advances.experience.spent = this.advances.experience.spent + attribute.cost;
             }
@@ -104,6 +105,7 @@ export class WrathAndGloryActor extends Actor {
         let middle = Object.values(this.skills).length / 2;
         let i = 0;
         for (let skill of Object.values(this.skills)) {
+            skill.cost = this.getSkillsCosts(skill.rating);
             skill.total = this.attributes[skill.attribute].total + skill.rating + skill.bonus;
             if (this.advances) {
                 this.advances.experience.spent = this.advances.experience.spent + skill.cost;
@@ -130,7 +132,7 @@ export class WrathAndGloryActor extends Actor {
     }
 
     _computeExperience() {
-        this.advances.experience.spent = this.advances.experience.spent + this.advances.species;
+        this.advances.experience.spent += this.advances.species;
         this.advances.experience.total = this.advances.experience.current + this.advances.experience.spent;
     }
 
@@ -162,4 +164,58 @@ export class WrathAndGloryActor extends Actor {
     get resources() {return this.data.data.resources}
     get corruption() {return this.data.data.corruption}
     get notes() {return this.data.data.notes}
+
+    getAttributeCosts(rating) {
+        switch (rating) {
+            case 1:
+                return 0;
+            case 2:
+                return 4;
+            case 3:
+                return 10;
+            case 4:
+                return 20;
+            case 5:
+                return 35;
+            case 6:
+                return 55;
+            case 7:
+                return 80;
+            case 8:
+                return 110;
+            case 9:
+                return 145;
+            case 10:
+                return 185;
+            case 11:
+                return 230;
+            case 12:
+                return 280;
+            default:
+                return 0;
+        }
+    }
+
+    getSkillsCosts(rating) {
+        switch (rating) {
+            case 1:
+                return 2;
+            case 2:
+                return 6;
+            case 3:
+                return 12;
+            case 4:
+                return 20;
+            case 5:
+                return 30;
+            case 6:
+                return 42;
+            case 7:
+                return 56;
+            case 8:
+                return 72;
+            default:
+                return 0;
+        }
+    }
 }

--- a/template/sheet/tab/advances.html
+++ b/template/sheet/tab/advances.html
@@ -3,17 +3,22 @@
     <div class="tier">
       <label class="name">{{localize "ADVANCE.TIER"}}</label>
       <input class="current" name="data.advances.tier" type="number" value="{{data.advances.tier}}"
+             min="1"
+             max="5"
         data-dtype="Number" />
 
     </div>
     <div class="rank">
       <label class="name">{{localize "ADVANCE.RANK"}}</label>
       <input class="current" name="data.advances.rank" type="number" value="{{data.advances.rank}}"
+             min="1"
+             max="4"
         data-dtype="Number" />
     </div>
     <div class="species">
       <label class="name">{{localize "BIO.SPECIES"}}</label>
       <input class="cost" name="data.advances.species" type="number" value="{{data.advances.species}}"
+             min="0"
         data-dtype="Number" />
     </div>
     <div class="experience">
@@ -44,9 +49,11 @@
       <div class="item">
         <label class="name">{{localize attribute.label}}</label>
         <input class="rating" name="data.attributes.{{key}}.rating" type="number" value="{{attribute.rating}}"
+          min="1" max="12"
           data-dtype="Number" />
         <input class="cost" name="data.attributes.{{key}}.cost" type="number" value="{{attribute.cost}}"
-          data-dtype="Number" />
+          min="0" max="280"
+          data-dtype="Number" readonly/>
       </div>
       {{/each}}
     </div>
@@ -63,8 +70,10 @@
       <div class="item">
         <label class="name">{{localize skill.label}}</label>
         <input class="rating" name="data.skills.{{key}}.rating" type="number" value="{{skill.rating}}"
+               min="0" max="8"
           data-dtype="Number" />
-        <input class="cost" name="data.skills.{{key}}.cost" type="number" value="{{skill.cost}}" data-dtype="Number" />
+        <input class="cost" name="data.skills.{{key}}.cost" type="number" value="{{skill.cost}}" data-dtype="Number"
+        min="0" max="72" readonly />
       </div>
       {{/each}}
     </div>


### PR DESCRIPTION
- Automate XP costs for skills and attributes.
- Make costs input fields readonly.
- Add min/max keywords to skills costs/rating, attributes costs/rating, tier and rank