### PR TITLE
Fix Importing Compendiums breaking folder structures

### DIFF
--- a/scripts/common/overrides.js
+++ b/scripts/common/overrides.js
@@ -22,7 +22,7 @@ export default function() {
     }
 
     // Eliminate some fields that should never be preserved
-    const deleteKeys = ["folder"];
+    const deleteKeys = [];
     for ( let k of deleteKeys ) {
       delete data[k];
     }


### PR DESCRIPTION
Removed `folder` from the list of keys to be deleted when importing compendiums. This was causing issues when importing nested compendiums such as:
- [Items]
  - [Weapons]
    - {Sword}
    - {Gun}
    - [Ammo]
      - {Gun Ammo}

To end up being imported as:
- [Items]
  - [Weapons]
    - [Ammo]
  - {Sword}
  - {Gun}
  - {Gun Ammo}