### PR TITLE
Small fix for random table roll chat messages

### DIFF
--- a/scripts/common/chat.js
+++ b/scripts/common/chat.js
@@ -38,7 +38,7 @@ export default class WNGChat {
           return ui.notifications.error(game.i18n.format("ROLL.CannotFindTable", {name : game.i18n.localize("TABLE.CRITICAL_HIT_TABLE")}))
         roll = new Roll(table.formula)
         result = await table.roll({ roll })
-        chatData = { content: result.results[0].text + ` (${result.roll.total})`, flavor: `Critical Hit` }
+        chatData = { content: result.results[0].getChatText() + ` (${result.roll.total})`, flavor: `Critical Hit` }
       }
     }
     if (test.result.isWrathComplication) {
@@ -48,7 +48,7 @@ export default class WNGChat {
           return ui.notifications.error(game.i18n.format("ROLL.CannotFindTable", {name : game.i18n.localize("TABLE.COMBAT_COMPLICATIONS")}))
         roll = new Roll(table.formula)
         result = await table.roll({ roll })
-        chatData = { content: result.results[0].text + ` (${result.roll.total})`, flavor: `Combat Complication` }
+        chatData = { content: result.results[0].getChatText() + ` (${result.roll.total})`, flavor: `Combat Complication` }
       }
       else if (test.power) {
         table = game.tables.getName(game.i18n.localize("TABLE.PERILS_OF_THE_WARP"))
@@ -57,7 +57,7 @@ export default class WNGChat {
         let modifier = (test.result.allDice.filter(die => die.name == "wrath-complication").length - 1) * 10
         roll = new Roll(table.formula + " + " + modifier)
         result = await table.roll({ roll })
-        chatData = { content: result.results[0].text + ` (${result.roll.total})`, flavor: `Perils of the Warp ${modifier ? "(+" + modifier + ")" : ""}` }
+        chatData = { content: result.results[0].getChatText() + ` (${result.roll.total})`, flavor: `Perils of the Warp ${modifier ? "(+" + modifier + ")" : ""}` }
       }
       else {
         table = game.tables.getName(game.i18n.localize("TABLE.COMPLICATION_CONSEQUENCES"))
@@ -65,7 +65,7 @@ export default class WNGChat {
           return ui.notifications.error(game.i18n.format("ROLL.CannotFindTable", {name : game.i18n.localize("TABLE.COMPLICATION_CONSEQUENCES")}))
         roll = new Roll(table.formula)
         result = await table.roll({ roll })
-        chatData = { content: result.results[0].text + ` (${result.roll.total})`, flavor: `Complication Consequence` }
+        chatData = { content: result.results[0].getChatText() + ` (${result.roll.total})`, flavor: `Complication Consequence` }
       }
     }
     if (chatData.content)


### PR DESCRIPTION
Chat messages handled only plain text for rolls from random tables. This fix allows for proper display of other types (for example macros) assigned to a roll result in the table.