### PR TITLE
Fix incorrect reference to item damage in chat item template

### DIFF
--- a/static/templates/chat/item.hbs
+++ b/static/templates/chat/item.hbs
@@ -44,7 +44,7 @@
 
             {{#if item.isWeapon}}
             <p><strong>{{localize "WEAPON.CATEGORY"}}:</strong> {{item.system.Category}}</p>
-            <p><strong>{{localize "WEAPON.DAMAGE"}}:</strong> {{itemsystem.damage.formatted}}</p>
+            <p><strong>{{localize "WEAPON.DAMAGE"}}:</strong> {{item.system.damage.formatted}}</p>
             <p><strong>{{localize "WEAPON.AP"}}:</strong> {{item.system.damage.AP}}</p>
             <p><strong>{{localize "WEAPON.ED"}}:</strong> {{item.system.damage.ED}}</p>
             <p><strong>{{localize "WEAPON.RANGE"}}:</strong> {{item.system.Range}}</p>


### PR DESCRIPTION
There was a problem with displaying weapons' damage on the chat.