### PR TITLE
Fix ownership of chat messages on roll edits

### DIFF
--- a/scripts/common/tests/test.js
+++ b/scripts/common/tests/test.js
@@ -478,7 +478,7 @@ export class WNGTest extends WarhammerTestBase {
       type: "test",
       rolls: [this.roll],
       system: this.data,
-      user: game.user.id,
+      user: this.message?.user || game.user.id,
       rollMode: this.context.rollMode,
       content: html,
       speaker: this.context.speaker


### PR DESCRIPTION
This addresses a bug where editing a test roll in a chat message transfers ownership of that message to the user performing the edit. This prevents the original player from taking further actions on their roll, such as rerolls.